### PR TITLE
Allow viewer maximizability and fix layer order when using domain bundles

### DIFF
--- a/src/main/js/bundles/dn_streetsmart/MarkerController.js
+++ b/src/main/js/bundles/dn_streetsmart/MarkerController.js
@@ -57,7 +57,7 @@ export default class MarkerController {
 
     activateMarker() {
         this._registerWatcher();
-        this._mapWidgetModel.map.reorder(graphicsLayer, 999)
+        this._mapWidgetModel.map.reorder(this.#graphicsLayer, 999)
     }
 
     deactivateMarker() {

--- a/src/main/js/bundles/dn_streetsmart/MarkerController.js
+++ b/src/main/js/bundles/dn_streetsmart/MarkerController.js
@@ -57,6 +57,7 @@ export default class MarkerController {
 
     activateMarker() {
         this._registerWatcher();
+        this._mapWidgetModel.map.reorder(graphicsLayer, 999)
     }
 
     deactivateMarker() {

--- a/src/main/js/bundles/dn_streetsmart/StreetSmartController.js
+++ b/src/main/js/bundles/dn_streetsmart/StreetSmartController.js
@@ -133,7 +133,7 @@ export default class StreetSmartController {
                 panoramaViewer: {
                     replace: true,
                     closable: false,
-                    maximizable: false
+                    maximizable: this.#streetSmartProperties.panoramaViewerMaximizable
                 }
             }).then(
                 result => {

--- a/src/main/js/bundles/dn_streetsmart/manifest.json
+++ b/src/main/js/bundles/dn_streetsmart/manifest.json
@@ -190,7 +190,8 @@
                         "locale": "de",
                         "database": "Nokia"
                     },
-                    "panoramaViewerInstance": null
+                    "panoramaViewerInstance": null,
+                    "panoramaViewerMaximizable": false
                 },
                 "streetSmartLayerId": null,
                 "markerSymbols": {


### PR DESCRIPTION
When using domain bundles, the marker was shown underneath the layers defined in the domain bundles. Commit f0fe3b6c56ae3aa899fb54ccd38140073c7e326c reorders the graphics layer containing the marker upon tool activation to be on top for improved visibility.

Commit fe9f09f82dac486df9edbe5451d6aa6162565b33 exposes the maximize option of the Panorama Viewer so it can be configured in the bundle. #5 